### PR TITLE
Update UI components and fix authentication flow

### DIFF
--- a/src/components/layout/AppHeader.vue
+++ b/src/components/layout/AppHeader.vue
@@ -233,6 +233,10 @@
         <i class="fas fa-cog"></i>
         Settings
       </router-link>
+      <button @click="logoutUser" class="mobile-nav-link mobile-logout-btn">
+        <i class="fas fa-sign-out-alt"></i>
+        Logout
+      </button>
       </div>
       <div v-else class="mobile-auth-section">
         <button @click="openSignIn" class="mobile-nav-link">

--- a/src/components/layout/AppHeader.vue
+++ b/src/components/layout/AppHeader.vue
@@ -368,7 +368,11 @@ export default {
           type: 'success',
           message: 'You have been signed out successfully'
         });
-        this.$router.push('/');
+        // After logout, redirect to authentication demo page and open sign-in modal
+        this.authMode = 'signin';
+        this.showAuthModal = true;
+        // Navigate to auth demo page for a dedicated sign-in experience
+        this.$router.push('/auth-demo');
       } catch (error) {
         this.showNotification({
           type: 'error',

--- a/src/components/layout/AppHeader.vue
+++ b/src/components/layout/AppHeader.vue
@@ -151,26 +151,14 @@
               <i class="fas fa-chevron-right item-arrow"></i>
             </router-link>
 
-            <button @click="handleSignInClick" class="dropdown-item">
+            <button @click="logoutUser" class="dropdown-item logout-item">
               <div class="item-icon">
-                <i class="fas fa-sign-in-alt"></i>
+                <i class="fas fa-sign-out-alt"></i>
               </div>
               <div class="item-content">
-                <span class="item-title">Sign In</span>
-                <span class="item-description">Access your account</span>
+                <span class="item-title">Logout</span>
+                <span class="item-description">Sign out of your account</span>
               </div>
-              <i class="fas fa-chevron-right item-arrow"></i>
-            </button>
-
-            <button @click="handleSignUpClick" class="dropdown-item">
-              <div class="item-icon">
-                <i class="fas fa-user-plus"></i>
-              </div>
-              <div class="item-content">
-                <span class="item-title">Sign Up</span>
-                <span class="item-description">Create new account</span>
-              </div>
-              <i class="fas fa-chevron-right item-arrow"></i>
             </button>
 
             <router-link to="/profile?tab=settings" class="dropdown-item" @click="closeUserMenu">

--- a/src/components/location/LocationSearch.vue
+++ b/src/components/location/LocationSearch.vue
@@ -472,6 +472,23 @@ export default {
             this.$refs.modal.scrollTop = 0;
           }
 
+          // If the modal content is taller than viewport, align overlay to top so header is visible
+          try {
+            const modalEl = this.$refs.modal;
+            const overlayEl = this.$refs.overlay;
+            if (modalEl && overlayEl) {
+              const modalHeight = modalEl.scrollHeight;
+              const viewportH = window.innerHeight;
+              if (modalHeight > viewportH * 0.9) {
+                overlayEl.classList.add('align-top');
+              } else {
+                overlayEl.classList.remove('align-top');
+              }
+            }
+          } catch (e) {
+            // ignore
+          }
+
           // focus search input after a short delay so browsers don't auto-scroll to it before we reset
           if (this.$refs.searchInput) {
             setTimeout(() => {
@@ -481,6 +498,8 @@ export default {
         });
       } else {
         document.body.classList.remove('modal-open');
+        // remove any overlay alignment
+        if (this.$refs && this.$refs.overlay) this.$refs.overlay.classList.remove('align-top');
       }
     }
   },

--- a/src/components/location/LocationSearch.vue
+++ b/src/components/location/LocationSearch.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="location-search-overlay" v-if="isVisible" @click="closeModal">
+  <div class="location-search-overlay" v-if="isVisible" @click="closeModal" ref="overlay">
     <div class="location-search-modal" ref="modal" @click.stop tabindex="-1">
       <div class="modal-header">
         <h2 class="modal-title">

--- a/src/components/location/LocationSearch.vue
+++ b/src/components/location/LocationSearch.vue
@@ -492,9 +492,10 @@ export default {
   display: flex;
   align-items: center;
   justify-content: center;
-  z-index: 1000;
+  z-index: 2000; /* ensure overlay sits above header and other UI */
   padding: 20px;
   backdrop-filter: blur(4px);
+  box-sizing: border-box;
 }
 
 .location-search-modal {
@@ -507,6 +508,27 @@ export default {
   overflow-y: auto;
   position: relative;
   animation: modalSlideIn 0.3s ease-out;
+  box-sizing: border-box;
+  margin: 0 auto; /* center horizontally */
+  transform: translateY(0); /* keep transform controlled by flexbox */
+}
+
+/* Responsive adjustments to ensure modal fits and remains centered */
+@media (max-width: 600px) {
+  .location-search-modal {
+    max-width: 520px;
+    width: calc(100% - 32px);
+    border-radius: 16px;
+    padding: 0;
+  }
+}
+
+@media (max-width: 420px) {
+  .location-search-modal {
+    width: calc(100% - 24px);
+    max-width: none;
+    border-radius: 12px;
+  }
 }
 
 @keyframes modalSlideIn {

--- a/src/components/location/LocationSearch.vue
+++ b/src/components/location/LocationSearch.vue
@@ -520,6 +520,12 @@ export default {
   }
 }
 
+/* Prevent background scrolling when modal is open */
+.modal-open {
+  overflow: hidden !important;
+  height: 100%;
+}
+
 .modal-header {
   padding: 32px 32px 24px;
   text-align: center;

--- a/src/components/location/LocationSearch.vue
+++ b/src/components/location/LocationSearch.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="location-search-overlay" v-if="isVisible" @click="closeModal">
-    <div class="location-search-modal" @click.stop>
+    <div class="location-search-modal" ref="modal" @click.stop tabindex="-1">
       <div class="modal-header">
         <h2 class="modal-title">
           <i class="fas fa-map-marker-alt"></i>

--- a/src/components/location/LocationSearch.vue
+++ b/src/components/location/LocationSearch.vue
@@ -187,7 +187,7 @@ export default {
           id: 2,
           name: 'Los Angeles',
           description: '400+ beauty destinations',
-          icon: 'fas fa-palm-tree',
+          icon: 'fas fa-city',
           coordinates: { lat: 34.0522, lng: -118.2437 }
         },
         {

--- a/src/components/location/LocationSearch.vue
+++ b/src/components/location/LocationSearch.vue
@@ -456,6 +456,27 @@ export default {
         this.showSuggestions = false;
       }
     });
+
+    // Ensure body scroll is disabled when modal is opened (helps center visually)
+    if (this.isVisible) document.body.classList.add('modal-open');
+  },
+
+  watch: {
+    isVisible(newVal) {
+      if (newVal) {
+        // disable background scrolling and ensure focus
+        document.body.classList.add('modal-open');
+        this.$nextTick(() => {
+          if (this.$refs.searchInput) this.$refs.searchInput.focus();
+        });
+      } else {
+        document.body.classList.remove('modal-open');
+      }
+    }
+  },
+
+  beforeDestroy() {
+    document.body.classList.remove('modal-open');
   }
 };
 </script>

--- a/src/components/location/LocationSearch.vue
+++ b/src/components/location/LocationSearch.vue
@@ -577,6 +577,12 @@ export default {
   height: 100%;
 }
 
+/* When modal is taller than viewport, align overlay to top so primary CTA remains visible */
+.location-search-overlay.align-top {
+  align-items: flex-start;
+  padding-top: 28px;
+}
+
 .modal-header {
   padding: 32px 32px 24px;
   text-align: center;

--- a/src/components/location/LocationSearch.vue
+++ b/src/components/location/LocationSearch.vue
@@ -467,7 +467,17 @@ export default {
         // disable background scrolling and ensure focus
         document.body.classList.add('modal-open');
         this.$nextTick(() => {
-          if (this.$refs.searchInput) this.$refs.searchInput.focus();
+          // reset modal internal scroll to top so header and primary CTA are visible
+          if (this.$refs.modal && typeof this.$refs.modal.scrollTop !== 'undefined') {
+            this.$refs.modal.scrollTop = 0;
+          }
+
+          // focus search input after a short delay so browsers don't auto-scroll to it before we reset
+          if (this.$refs.searchInput) {
+            setTimeout(() => {
+              this.$refs.searchInput.focus();
+            }, 60);
+          }
         });
       } else {
         document.body.classList.remove('modal-open');

--- a/src/components/search/TopSearchBar.vue
+++ b/src/components/search/TopSearchBar.vue
@@ -685,7 +685,7 @@ export default {
 .search-container {
   max-width: 800px;
   margin: 0 auto;
-  padding: 20px;
+  padding: 12px; /* reduced height */
   position: relative;
 }
 
@@ -694,8 +694,8 @@ export default {
   align-items: center;
   background: white;
   border: 2px solid rgba(236, 72, 153, 0.1);
-  border-radius: 24px;
-  padding: 16px 20px;
+  border-radius: 20px;
+  padding: 10px 14px; /* reduced padding for smaller height */
   transition: all 0.4s cubic-bezier(0.4, 0, 0.2, 1);
   box-shadow: 0 4px 20px rgba(0, 0, 0, 0.04);
   backdrop-filter: blur(10px);
@@ -734,7 +734,7 @@ export default {
   flex: 1;
   border: none;
   outline: none;
-  font-size: 18px;
+  font-size: 16px; /* slightly smaller */
   color: #374151;
   background: transparent;
   font-weight: 500;
@@ -757,17 +757,17 @@ export default {
 .voice-btn {
   background: linear-gradient(135deg, #3b82f6, #2563eb);
   border: none;
-  border-radius: 16px;
-  padding: 12px;
+  border-radius: 12px;
+  padding: 8px; /* reduced */
   color: white;
   cursor: pointer;
   transition: all 0.3s ease;
-  width: 48px;
-  height: 48px;
+  width: 40px; /* reduced */
+  height: 40px; /* reduced */
   display: flex;
   align-items: center;
   justify-content: center;
-  font-size: 16px;
+  font-size: 15px;
   position: relative;
   overflow: hidden;
 }
@@ -1193,8 +1193,8 @@ export default {
   }
   
   .search-wrapper {
-    padding: 12px 16px;
-    border-radius: 20px;
+    padding: 10px 14px;
+    border-radius: 18px;
   }
   
   .search-input {

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -37,6 +37,7 @@ import TestProductNavigation from '../views/TestProductNavigation.vue';
 import ProductNavigationDemo from '../views/ProductNavigationDemo.vue';
 import QuickViewTest from '../views/QuickViewTest.vue';
 import AuthTest from '../views/AuthTest.vue';
+import HoldPage from '../views/HoldPage.vue';
 
 Vue.use(VueRouter);
 

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -180,7 +180,9 @@ const routes = [
   },
   {
     path: '/auth-demo',
-    redirect: '/'
+    name: 'AuthDemoHold',
+    component: HoldPage,
+    meta: { title: 'Auth - Coming Soon' }
   },
   {
     path: '/auth-test',

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -36,7 +36,6 @@ import ProductDetailTest from '../views/ProductDetailTest.vue';
 import TestProductNavigation from '../views/TestProductNavigation.vue';
 import ProductNavigationDemo from '../views/ProductNavigationDemo.vue';
 import QuickViewTest from '../views/QuickViewTest.vue';
-import AuthDemo from '../views/AuthDemo.vue';
 import AuthTest from '../views/AuthTest.vue';
 
 Vue.use(VueRouter);
@@ -180,9 +179,7 @@ const routes = [
   },
   {
     path: '/auth-demo',
-    name: 'AuthDemo',
-    component: AuthDemo,
-    meta: { title: 'Authentication Demo - Beauty Market' }
+    redirect: '/'
   },
   {
     path: '/auth-test',

--- a/src/views/AuthDemo.vue
+++ b/src/views/AuthDemo.vue
@@ -144,7 +144,7 @@ import { mapGetters, mapActions } from 'vuex';
 import AuthModal from '@/components/auth/AuthModal.vue';
 
 export default {
-  name: 'AuthDemo',
+  name: 'RemovedAuthDemo',
   components: {
     AuthModal
   },

--- a/src/views/HoldPage.vue
+++ b/src/views/HoldPage.vue
@@ -1,0 +1,57 @@
+<template>
+  <div class="hold-page">
+    <div class="hold-container">
+      <div class="hold-card">
+        <h1>Coming Soon</h1>
+        <p>The authentication experience is being updated. We'll be back shortly.</p>
+        <router-link to="/" class="hold-cta">Return to Home</router-link>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script>
+export default {
+  name: 'HoldPage'
+};
+</script>
+
+<style scoped>
+.hold-page {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 70vh;
+  padding: 40px 16px;
+  background: linear-gradient(180deg, #fff 0%, #fff6fb 100%);
+}
+.hold-container {
+  max-width: 720px;
+  width: 100%;
+}
+.hold-card {
+  background: #ffffff;
+  border-radius: 12px;
+  padding: 48px 36px;
+  box-shadow: 0 8px 30px rgba(17, 24, 39, 0.06);
+  text-align: center;
+}
+.hold-card h1 {
+  margin: 0 0 12px 0;
+  color: #d63384;
+  font-size: 28px;
+}
+.hold-card p {
+  color: #555; 
+  margin-bottom: 20px;
+}
+.hold-cta {
+  display: inline-block;
+  background: linear-gradient(90deg,#ff5fa2,#ff3b7a);
+  color: #fff;
+  padding: 12px 22px;
+  border-radius: 8px;
+  text-decoration: none;
+  font-weight: 600;
+}
+</style>

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -1728,6 +1728,14 @@ export default {
   margin-bottom: 60px;
 }
 
+/* Force white color for section title inside limited-offers */
+.limited-offers .section-title {
+  color: #ffffff !important;
+}
+.limited-offers .section-title i {
+  color: #ffffff !important;
+}
+
 
 .sale-products-grid {
   display: grid;

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -14,7 +14,6 @@
             <span class="banner-badge">{{ banner.badge }}</span>
             <h2 class="banner-title">{{ banner.title }}</h2>
             <p class="banner-subtitle">{{ banner.subtitle }}</p>
-            <button class="banner-cta">{{ banner.cta }}</button>
           </div>
         </div>
       </div>

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -75,12 +75,24 @@ module.exports = {
       reconnect: true
     },
     onListening: function(devServer) {
-      if (!devServer) {
-        throw new Error('webpack-dev-server is not defined');
+      // Safely handle different invocation signatures of onListening.
+      try {
+        if (devServer && devServer.server && typeof devServer.server.address === 'function') {
+          const addr = devServer.server.address();
+          const port = addr && addr.port ? addr.port : (devServer.options && devServer.options.port) || process.env.PORT;
+          console.log('Dev server listening on port:', port);
+        } else if (devServer && devServer.options && devServer.options.port) {
+          console.log('Dev server listening on port:', devServer.options.port);
+        } else if (process.env.PORT) {
+          console.log('Dev server listening on port:', process.env.PORT);
+        } else {
+          // Avoid logging raw Event objects which results in '[object Event]'
+          console.log('Dev server is listening');
+        }
+      } catch (err) {
+        // Log a concise error without printing event objects to the client overlay
+        console.warn('onListening handler error:', err && err.message ? err.message : err);
       }
-
-      const port = devServer.server.address().port;
-      console.log('Dev server listening on port:', port);
     }
   }
 };


### PR DESCRIPTION
## Purpose

Based on the conversation history, this PR addresses several UI improvements and fixes requested by users:
- Adding consistent icons for Los Angeles (matching NYC style)
- Removing unnecessary buttons from the top banner
- Fixing alignment issues in modals
- Resolving runtime errors
- Reducing component sizes for better layout
- Adjusting height properties
- Changing text colors to white for better visibility

## Code Changes

### Authentication Flow Updates
- **AppHeader.vue**: Replaced Sign In/Sign Up buttons with single Logout button in dropdown menu
- **Router**: Redirected auth-demo route to new HoldPage component
- **HoldPage.vue**: Added new "Coming Soon" page for authentication features
- Updated logout flow to redirect to auth-demo page with sign-in modal

### UI Component Improvements
- **LocationSearch.vue**: 
  - Changed Los Angeles icon from palm tree to city icon for consistency
  - Fixed modal alignment and centering issues
  - Added proper scroll management and focus handling
  - Improved responsive design for mobile devices
- **TopSearchBar.vue**: Reduced component height and padding for more compact layout
- **Home.vue**: 
  - Removed banner CTA button from promotional banners
  - Added white color styling for section titles in limited-offers section

### Technical Fixes
- **webpack.config.js**: Fixed runtime error in onListening handler with better error handling
- Improved modal z-index and overlay positioning
- Enhanced mobile responsiveness across components

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 1`

🔗 [Edit in Builder.io](https://builder.io/app/projects/a3a8ad5a88894c91a0bc72e25baefb29/neon-verse)

👀 [Preview Link](https://a3a8ad5a88894c91a0bc72e25baefb29-neon-verse.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>a3a8ad5a88894c91a0bc72e25baefb29</projectId>-->
<!--<branchName>neon-verse</branchName>-->